### PR TITLE
change name of the function for readable purpose

### DIFF
--- a/src/components/pages/Mentor/MentorPairing.js
+++ b/src/components/pages/Mentor/MentorPairing.js
@@ -2,10 +2,9 @@ import React, { useEffect, useState } from 'react';
 import {
   fetchMentees,
   fetchMentors,
-  editMentor,
+  editMatches,
   cancelMatches,
 } from '../../../state/actions';
-import { axiosWithAuth } from '../../../utils/axiosWithAuth';
 import { useSelector, connect } from 'react-redux';
 import { Descriptions, Select, Button } from 'antd';
 import { Popconfirm, message } from 'antd';
@@ -16,14 +15,13 @@ import './MentorPairing.css';
 const MentorPairing = ({
   fetchMentors,
   fetchMentees,
-  editMentor,
+  editMatches,
   cancelMatches,
 }) => {
   const { Option } = Select;
   const [mentor, setMentor] = useState({});
   const [menteeId, setMenteeId] = useState(-1);
-  console.log('MENTOR: ', mentor, '\nMENTEE: ', menteeId);
-  //   const [matched, setMatched] = useState([]);
+
   const state = useSelector(state => ({ ...state }));
 
   const { mentees } = state.menteeReducer;
@@ -60,7 +58,7 @@ const MentorPairing = ({
     eachMentor.subjects.map(eachSubject => `${eachSubject}`);
 
   const handleUpdate = (mentor, menteeId) => {
-    editMentor(mentor, menteeId);
+    editMatches(mentor, menteeId);
     fetchMentors();
   };
 
@@ -164,7 +162,6 @@ const MentorPairing = ({
               <Popconfirm
                 title="Are you sure to delete this task?"
                 onConfirm={() => confirm(eachMentor)}
-                //  onCancel={cancel}
                 okText="Yes"
                 cancelText="No"
               >
@@ -185,6 +182,6 @@ const mapStateToProps = state => {
 export default connect(mapStateToProps, {
   fetchMentees,
   fetchMentors,
-  editMentor,
+  editMatches,
   cancelMatches,
 })(MentorPairing);

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -152,7 +152,7 @@ export const fetchMentors = () => async dispatch => {
   dispatch({ type: actionTypes.FETCH_MENTOR_SUCCESS, payload: mentors.data });
 };
 
-export const editMentor = (mentor, menteeId) => dispatch => {
+export const editMatches = (mentor, menteeId) => dispatch => {
   dispatch({ type: actionTypes.EDIT_MENTOR_START, payload: mentor });
   axiosWithAuth()
     .put(`/mentor/${mentor.id}`, { ...mentor, mentee: menteeId })


### PR DESCRIPTION
change the name of the function `editMentor` to `editMatches` which is more readable and easy to understand the purpose of the function.