### PR TITLE
Fixed up some styling issues with the teach approval page

### DIFF
--- a/src/components/pages/Headmaster/HeadmasterDashboard.css
+++ b/src/components/pages/Headmaster/HeadmasterDashboard.css
@@ -103,8 +103,21 @@
   flex-direction: column;
   align-items: flex-start;
 }
+
+.teacher-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+}
+.confirm-deny-container {
+  margin-bottom: 0.25rem;
+}
 @media screen and (max-width: 800px) {
   .headmasterDashboard {
     margin-left: 0;
   }
 }
+

--- a/src/components/pages/Headmaster/TeacherApproval/TeacherApproval.js
+++ b/src/components/pages/Headmaster/TeacherApproval/TeacherApproval.js
@@ -60,19 +60,20 @@ function TeacherApproval(props) {
       {props.pendingTeachers.map((teacher, ind) => {
         return (
           <div key={`${teacher.id}-${ind}`}>
-            <p>{`${teacher.first_name} ${teacher.last_name}`}</p>
-            <Label>Actions:</Label>
-            <div className="confirm-deny-container">
-              <Button onClick={e => onConfirmClick(e, teacher.id)}>
-                Confirm
-              </Button>
-              <Button
-                onClick={e =>
-                  onDenyClick(e, props.headMasterProfile.schoolId, teacher.id)
-                }
-              >
-                Deny
-              </Button>
+            <div className="teacher-container">
+              {`${teacher.first_name} ${teacher.last_name}`}
+              <span className="confirm-deny-container">
+                <Button onClick={e => onConfirmClick(e, teacher.id)}>
+                  Confirm
+                </Button>
+                <Button
+                  onClick={e =>
+                    onDenyClick(e, props.headMasterProfile.schoolId, teacher.id)
+                  }
+                >
+                  Deny
+                </Button>
+              </span>
             </div>
           </div>
         );


### PR DESCRIPTION
The styling and markup structure of the teacher approval page for the Headmaster dashboard needed some changes. This should make the structure flow much better.

![approval_styling](https://user-images.githubusercontent.com/48367657/106785398-58820c00-661b-11eb-9675-01186164a55d.PNG)
